### PR TITLE
Add FastAPI chat backend with OpenAI responses API and news tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,109 @@
-# mindmate
+# 🧠 MindMate
+
 A personal AI assistant that helps you stay organized, informed, and in control
+
+---
+
+## 🚀 Features
+
+- 💬 Chat endpoint backed by OpenAI GPT-4o (`responses.create`)
+- 🔧 Tool calling support (e.g., fetch latest news)
+- 🌐 FastAPI server with auto-reload support via `uvicorn`
+- 🔐 Environment config via `.env`
+- 🧪 Local development with virtualenv + pyenv
+
+---
+
+## 🛠️ Setup
+
+### 1. Install Python (with OpenSSL)
+Make sure your Python is compiled with OpenSSL ≥ 1.1.1. Recommended setup:
+
+```bash
+brew install openssl xz
+env \
+  LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix xz)/lib" \
+  CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix xz)/include" \
+  PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig:$(brew --prefix xz)/lib/pkgconfig" \
+  pyenv install 3.9.18
+pyenv local 3.9.18
+```
+
+### 2. Create virtual environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+### 3. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## 🔑 Environment Variables
+
+Create a `.env` file with your OpenAI key:
+
+```
+OPENAI_API_KEY=sk-...
+```
+
+---
+
+## 🧪 Running the App
+
+Start the local server:
+
+```bash
+uvicorn main:app --reload --port 8000
+```
+
+Then send a request:
+
+```bash
+curl -s -X POST http://localhost:8000/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id":"immi", "message":"What’s the latest on Nvidia?"}'
+```
+
+---
+
+## 🧩 Project Structure
+
+```
+mindmate/
+├── main.py              # FastAPI app with OpenAI integration
+├── tools/
+│   └── news.py          # Custom tool implementation (e.g., fetch news)
+├── requirements.txt     # Python dependencies
+├── .venv/               # Virtual environment (not committed)
+└── .python-version      # Locked Python version via pyenv
+```
+
+---
+
+## 🧼 Notes
+
+- Uses OpenAI's [`responses.create`](https://platform.openai.com/docs/guides/gpt/function-calling) API with function calling
+- Output depends on implementation of `get_latest_news()` in `tools/news.py`
+- Logging is configured via `logging` module (INFO + DEBUG levels)
+
+---
+
+## ✅ Example Output
+
+```json
+{
+  "reply": "Here are the latest updates on Nvidia:\n\n1. [Breaking Nvidia News #1](https://example.com/nvidia/1)..."
+}
+```
+
+---
+
+## 📎 License
+
+Private / Internal Use Only — Immanuel Baur © 2025

--- a/main.py
+++ b/main.py
@@ -1,0 +1,139 @@
+import json
+import logging
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from dotenv import load_dotenv
+from openai import OpenAI
+from tools.news import get_latest_news
+# import memory  # optional conversation store
+
+# ── logging setup ───────────────────────────────────────────────────────────
+logging.basicConfig(
+    level=logging.DEBUG,  # set to INFO or WARNING in production
+    format="%(asctime)s [%(levelname)s] %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+# ── environment and OpenAI client setup ─────────────────────────────────────
+load_dotenv()
+client = OpenAI()
+app = FastAPI()
+
+# ── OpenAI function tool definition ─────────────────────────────────────────
+# This schema enables the model to call external functions like get_latest_news()
+tools = [
+    {
+        "type": "function",
+        "name": "get_latest_news",
+        "description": "Fetch the most recent headlines for a topic.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "News topic"
+                },
+                "max_items": {
+                    "type": "integer",
+                    "description": "How many articles to return",
+                    "default": 3
+                }
+            },
+            "required": ["topic"],
+            "additionalProperties": False  # strict schema enforcement
+        }
+    }
+]
+
+# ── DTOs for FastAPI request/response payloads ──────────────────────────────
+class ChatRequest(BaseModel):
+    user_id: str
+    message: str
+
+class ChatResponse(BaseModel):
+    reply: str
+
+# ── POST /chat endpoint ─────────────────────────────────────────────────────
+@app.post("/chat", response_model=ChatResponse)
+def chat(req: ChatRequest):
+    # Initial message history sent to the model
+    # Optional: replace with memory.history(req.user_id) for persistence
+    history = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": req.message},
+    ]
+
+    # ── First model call ─────────────────────────────────────────────────────
+    try:
+        logger.info("Sending initial prompt to model...")
+        logger.debug(f"History: {json.dumps(history, indent=2)}")
+        logger.debug(f"Tools: {json.dumps(tools, indent=2)}")
+        model_response = client.responses.create(
+            model="gpt-4o-mini",
+            input=history,
+            tools=tools,
+        )
+        logger.debug(f"Model raw response: {model_response}")
+    except Exception as e:
+        logger.exception("Failed during initial model call.")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    # ── Handle model output ──────────────────────────────────────────────────
+    output = model_response.output[0]
+
+    if output.type == "text":
+        # Model returned a direct answer, return it as-is
+        logger.info("Received direct text response from model.")
+        return ChatResponse(reply=output.text)
+
+    elif output.type == "function_call":
+        # Model requested a tool to be called
+        logger.info(f"Model requested tool invocation: {output.name}")
+
+        # Parse function arguments from model
+        try:
+            function_args = json.loads(output.arguments)
+            logger.debug(f"Parsed tool arguments: {function_args}")
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse function arguments: {e}")
+            raise HTTPException(status_code=500, detail=f"bad tool args: {e}")
+
+        # Call the actual backend tool
+        try:
+            tool_result = get_latest_news(**function_args)
+            logger.info("Tool executed successfully.")
+        except Exception as e:
+            logger.exception("Tool execution failed.")
+            raise HTTPException(status_code=500, detail=f"news fetch failed: {e}")
+
+        # Update the history with the tool response for a second model call
+        history.extend([
+            output,  # model's function_call
+            {
+                "type": "function_call_output",
+                "call_id": output.call_id,
+                "output": json.dumps(tool_result),
+            },
+        ])
+
+        # ── Final model call with tool output ────────────────────────────────
+        try:
+            logger.info("Sending tool result back to model for final answer...")
+            # logger.debug(f"Updated history: " + json.dumps(history, indent=2)) 
+            # logger.debug(f"Tools: {json.dumps(tools, indent=2)}")
+            final_response = client.responses.create(
+                model="gpt-4o-mini",
+                input=history,
+                tools=tools,
+            )
+            logger.debug(f"Final model response: {final_response}")
+        except Exception as e:
+            logger.exception("Failed during final model call.")
+            raise HTTPException(status_code=500, detail=str(e))
+
+        return ChatResponse(reply=final_response.output_text)
+
+    else:
+        # Unknown model output type — likely an SDK or logic error
+        logger.error(f"Unexpected response type from model: {output.type}")
+        raise HTTPException(status_code=500, detail="unexpected response type")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+openai
+python-dotenv
+tiktoken
+langchain
+chromadb

--- a/tools/news.py
+++ b/tools/news.py
@@ -1,0 +1,22 @@
+import os, requests, datetime, json
+
+NEWS_API_KEY = os.getenv("NEWS_API_KEY")  # optional; otherwise use free endpoints
+
+def get_latest_news(topic: str, max_items: int = 3) -> list[dict]:
+    """
+    Mocked news fetcher – returns static fake results for testing.
+    """
+    if not topic:
+        raise ValueError("topic required")
+
+    from datetime import datetime, timedelta
+
+    now = datetime.utcnow()
+    return [
+        {
+            "title": f"Breaking {topic} News #{i+1}",
+            "url": f"https://example.com/{topic.lower()}/{i+1}",
+            "published_at": (now - timedelta(hours=i)).isoformat() + "Z",
+        }
+        for i in range(max_items)
+    ]


### PR DESCRIPTION
- Implement /chat endpoint using FastAPI and OpenAI's responses.create
- Integrate function calling for get_latest_news via tools/news.py
- Add structured logging with log levels
- Setup pyenv + venv support (Python 3.9.18 + OpenSSL)
- Provide curl example and project overview in README.md