### PR TITLE
feat: add basic web interface to interact with orchestrator (#3)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1,0 +1,4 @@
+body { font-family: sans-serif; max-width: 600px; margin: 2rem auto; }
+#msgInput { width: 100%; padding: 0.4rem; }
+#callBtn  { margin: 0.5rem 0; padding: 0.4rem 1rem; }
+#output   { width: 100%; height: 200px; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>MindMate Chat Tester</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <h1>MindMate Chat</h1>
+
+  <!-- message input -->
+  <input id="msgInput" type="text" placeholder="Ask something…" />
+
+  <!-- trigger -->
+  <button id="callBtn">Send</button>
+
+  <!-- response area -->
+  <textarea id="output" readonly></textarea>
+
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1,0 +1,33 @@
+const API_URL = "http://127.0.0.1:8000/chat";   // adjust if backend port differs
+const USER_ID = "immi";                         // hard-coded for now
+
+const btn   = document.getElementById("callBtn");
+const input = document.getElementById("msgInput");
+const out   = document.getElementById("output");
+
+btn.addEventListener("click", async () => {
+  const message = input.value.trim();
+  if (!message) {
+    alert("Please type a message first.");
+    input.focus();
+    return;
+  }
+
+  out.value = "⏳ Waiting for server…";
+
+  try {
+    const res = await fetch(API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: USER_ID, message })
+    });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const data = await res.json();           // { reply: "..." }
+    out.value  = data.reply;
+  } catch (err) {
+    console.error(err);
+    out.value = `❌ ${err}`;
+  }
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mindmate-frontend",
+  "version": "1.0.0",
+  "description": "Frontend for Mindmate AI assistant",
+  "main": "index.html",
+  "scripts": {
+    "serve": "python -m http.server 3000",
+    "dev": "npm run serve"
+  },
+  "keywords": [
+    "ai",
+    "chatbot",
+    "frontend",
+    "javascript"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {},
+  "dependencies": {}
+}

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from dotenv import load_dotenv
 from openai import OpenAI
 from tools.news import get_latest_news
+from fastapi.middleware.cors import CORSMiddleware
 # import memory  # optional conversation store
 
 # ── logging setup ───────────────────────────────────────────────────────────
@@ -18,6 +19,14 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 client = OpenAI()
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # or ["http://localhost:3000"] for stricter control
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # ── OpenAI function tool definition ─────────────────────────────────────────
 # This schema enables the model to call external functions like get_latest_news()
@@ -81,10 +90,10 @@ def chat(req: ChatRequest):
     # ── Handle model output ──────────────────────────────────────────────────
     output = model_response.output[0]
 
-    if output.type == "text":
+    if output.type == "message":
         # Model returned a direct answer, return it as-is
         logger.info("Received direct text response from model.")
-        return ChatResponse(reply=output.text)
+        return ChatResponse(reply=output.content[0].text)
 
     elif output.type == "function_call":
         # Model requested a tool to be called


### PR DESCRIPTION
- Added CORS middleware to FastAPI server to allow frontend requests
- Introduced frontend scaffold under /frontend with HTML/CSS/JS
- Hooked up POST /chat endpoint from JS to server
- Fixed output.type check to handle 'message' instead of 'text'